### PR TITLE
Setup CI and shorten interval

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: dtolnay/rust-toolchain@stable
+      - name: Build
+        run: cargo build --verbose
+      - name: Run basic check
+        run: |
+          timeout -k 3 ./target/debug/fuzmon > output.txt 2>&1 || true
+          test -s output.txt

--- a/src/main.rs
+++ b/src/main.rs
@@ -18,6 +18,6 @@ fn main() {
     loop {
         let pids = read_pids();
         println!("Found {} PIDs: {:?}", pids.len(), pids);
-        thread::sleep(Duration::from_secs(5));
+        thread::sleep(Duration::from_secs(1));
     }
 }


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow for CI
- check that running `timeout -k 3 fuzmon` produces output
- reduce loop delay from five seconds to one second

## Testing
- `cargo test`
- `timeout -k 3 ./target/debug/fuzmon > /tmp/out.txt 2>&1 || true`

------
https://chatgpt.com/codex/tasks/task_e_684cf557704c8322ab25f9873b32338c