### PR TITLE
Improve stack trace output with symbol info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,28 @@
 version = 4
 
 [[package]]
+name = "addr2line"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9acbfca36652500c911ddb767ed433e3ed99b032b5d935be73c6923662db1d43"
+dependencies = [
+ "cpp_demangle",
+ "fallible-iterator",
+ "gimli",
+ "memmap2",
+ "object",
+ "rustc-demangle",
+ "smallvec",
+ "typed-arena",
+]
+
+[[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "bitflags"
 version = "2.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -21,10 +43,57 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
 
 [[package]]
+name = "cpp_demangle"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "crc32fast"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "flate2"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fuzmon"
 version = "0.1.0"
 dependencies = [
+ "addr2line",
+ "memmap2",
  "nix",
+ "object",
+]
+
+[[package]]
+name = "gimli"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
+dependencies = [
+ "fallible-iterator",
+ "stable_deref_trait",
 ]
 
 [[package]]
@@ -32,6 +101,30 @@ name = "libc"
 version = "0.2.173"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8cfeafaffdbc32176b64fb251369d52ea9f0a8fbc6f8759edffef7b525d64bb"
+
+[[package]]
+name = "memchr"
+version = "2.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a282da65faaf38286cf3be983213fcf1d2e2a58700e808f83f4ea9a4804bc0"
+
+[[package]]
+name = "memmap2"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+]
 
 [[package]]
 name = "nix"
@@ -44,3 +137,53 @@ dependencies = [
  "cfg_aliases",
  "libc",
 ]
+
+[[package]]
+name = "object"
+version = "0.37.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03fd943161069e1768b4b3d050890ba48730e590f57e56d4aa04e7e090e61b4a"
+dependencies = [
+ "flate2",
+ "memchr",
+ "ruzstd",
+]
+
+[[package]]
+name = "rustc-demangle"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "989e6739f80c4ad5b13e0fd7fe89531180375b18520cc8c82080e4dc4035b84f"
+
+[[package]]
+name = "ruzstd"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3640bec8aad418d7d03c72ea2de10d5c646a598f9883c7babc160d91e3c1b26c"
+dependencies = [
+ "twox-hash",
+]
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+
+[[package]]
+name = "stable_deref_trait"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
+
+[[package]]
+name = "twox-hash"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b907da542cbced5261bd3256de1b3a1bf340a3d37f93425a07362a1d687de56"
+
+[[package]]
+name = "typed-arena"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,6 @@ edition = "2024"
 
 [dependencies]
 nix = { version = "0.28", features = ["ptrace", "process"] }
+addr2line = "0.25"
+object = "0.37"
+memmap2 = "0.9"

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
-use std::{env, fs};
+use std::{env, fs, borrow::Cow};
+use addr2line::Loader;
 use nix::sys::{ptrace, wait::waitpid};
 use nix::unistd::Pid;
 
@@ -21,6 +22,63 @@ fn parse_pid() -> Option<i32> {
         }
     }
     None
+}
+
+fn find_base_address(pid: i32) -> Option<u64> {
+    let exe = fs::read_link(format!("/proc/{}/exe", pid)).ok()?;
+    let maps = fs::read_to_string(format!("/proc/{}/maps", pid)).ok()?;
+    for line in maps.lines() {
+        if line.contains(exe.to_str()?) {
+            let mut parts = line.split_whitespace();
+            if let (Some(range), Some(perms), Some(offset)) = (parts.next(), parts.next(), parts.next()) {
+                if offset == "00000000" && perms.starts_with('r') && perms.contains('x') {
+                    if let Some(start) = range.split('-').next() {
+                        if let Ok(addr) = u64::from_str_radix(start, 16) {
+                            return Some(addr);
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+fn load_loader(pid: i32) -> Option<(Loader, u64)> {
+    let exe_path = fs::read_link(format!("/proc/{}/exe", pid)).ok()?;
+    let loader = Loader::new(&exe_path).ok()?;
+    let base = find_base_address(pid)?;
+    Some((loader, base))
+}
+
+fn describe_addr(loader: &Loader, base: u64, addr: u64) -> Option<String> {
+    let probe = addr.wrapping_sub(base).wrapping_add(loader.relative_address_base());
+    let mut info = String::new();
+    if let Some(sym) = loader.find_symbol(probe) {
+        info.push_str(sym);
+    }
+    if let Ok(mut frames) = loader.find_frames(probe) {
+        let mut first = true;
+        while let Ok(Some(frame)) = frames.next() {
+            if !first {
+                info.push_str(" (inlined by) ");
+            }
+            first = false;
+            if let Some(func) = frame.function {
+                if !info.is_empty() {
+                    info.push(' ');
+                }
+                let name = func.demangle().unwrap_or_else(|_| Cow::from("??"));
+                info.push_str(&name);
+            }
+            if let Some(loc) = frame.location {
+                if let (Some(file), Some(line)) = (loc.file, loc.line) {
+                    info.push_str(&format!(" at {}:{}", file, line));
+                }
+            }
+        }
+    }
+    if info.is_empty() { None } else { Some(info) }
 }
 
 fn get_stack_trace(pid: Pid, max_frames: usize) -> nix::Result<Vec<u64>> {
@@ -52,9 +110,18 @@ fn attach_and_trace(pid: i32) -> nix::Result<()> {
 
     let res = (|| {
         let stack = get_stack_trace(target, 32)?;
+        let loader = load_loader(pid);
         println!("Stack trace for pid {}:", pid);
         for (i, addr) in stack.iter().enumerate() {
-            println!("{:>2}: {:#x}", i, addr);
+            if let Some((ref l, base)) = loader {
+                if let Some(info) = describe_addr(l, base, *addr) {
+                    println!("{:>2}: {:#x} {}", i, addr, info);
+                } else {
+                    println!("{:>2}: {:#x}", i, addr);
+                }
+            } else {
+                println!("{:>2}: {:#x}", i, addr);
+            }
         }
         Ok(())
     })();


### PR DESCRIPTION
## Summary
- show symbolicated stack traces using `addr2line`
- add helper functions for base address and symbol loading
- update dependencies for symbolization

## Testing
- `cargo build`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684cf84e32188322af52d33118176784