### PR TITLE
Support PID monitoring loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,8 @@ Python processes are traced using an embedded `py-spy` integration when possible
 ```
 fuzmon -o logs/             # write logs under ./logs
 fuzmon -c config.toml       # use configuration file
+# monitor a specific PID and write logs
+fuzmon -p 1234 -o logs/
 # logs default to /tmp/fuzmon when -o not specified
 ```
 

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -30,16 +30,23 @@ if __name__ == '__main__':
     thread::sleep(Duration::from_millis(500));
     let pid = child.id();
 
-    let output = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args(["-p", &pid.to_string()])
-        .output()
+    let logdir = tempdir().expect("logdir");
+    let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .args(["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()])
+        .stdout(Stdio::null())
+        .spawn()
         .expect("run fuzmon");
+
+    thread::sleep(Duration::from_millis(800));
+    let _ = mon.kill();
+    let _ = mon.wait();
 
     let _ = child.kill();
     let _ = child.wait();
 
-    let stdout = String::from_utf8_lossy(&output.stdout);
-    assert!(stdout.contains("foo"), "{}", stdout);
-    assert!(stdout.contains("bar"), "{}", stdout);
-    assert!(stdout.contains("test.py"), "{}", stdout);
+    let log_path = logdir.path().join(format!("{}.log", pid));
+    let log = fs::read_to_string(log_path).expect("read log");
+    assert!(log.contains("foo"), "{}", log);
+    assert!(log.contains("bar"), "{}", log);
+    assert!(log.contains("test.py"), "{}", log);
 }


### PR DESCRIPTION
## Summary
- monitor a single PID without exiting immediately
- save stack traces for the specified PID into log files
- update tests for new behaviour
- document `-p` usage in README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e32ff2ba0832282710e539ad517b0