### PR TITLE
Improve stacktrace symbolization for libraries

### DIFF
--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -47,7 +47,7 @@ int main() {
     let logdir = tempdir().expect("logdir");
     common::run_fuzmon_and_check(
         &["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()],
-        &["target_function", "main", "testprog.c"],
+        &["target_function", "main", "sleep", "testprog.c"],
     );
 
     let _ = child.kill();
@@ -98,7 +98,7 @@ int main() {
     let logdir = tempdir().expect("logdir");
     common::run_fuzmon_and_check(
         &["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()],
-        &["target_function", "main", "testprog.c"],
+        &["target_function", "main", "sleep", "testprog.c"],
     );
 
     let _ = child.kill();


### PR DESCRIPTION
## Summary
- parse `/proc/<pid>/maps` to register all executable mappings
- look up address info across loaded modules
- assert that libc's `sleep` appears in stacktrace tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e44b1b9888322836166389faddfe5