### PR TITLE
Add GCC flag variants to symbol tests

### DIFF
--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -5,11 +5,12 @@ use tempfile::tempdir;
 
 mod common;
 
-#[test]
-fn symbolized_stack_trace_contains_function() {
+fn run_symbol_test(flags: &[&str], expected: &[&str]) {
     let dir = tempdir().expect("tempdir");
     let src_path = dir.path().join("testprog.c");
-    fs::write(&src_path, r#"
+    fs::write(
+        &src_path,
+        r#"
 #include <unistd.h>
 
 void target_function() {
@@ -22,16 +23,18 @@ int main() {
     target_function();
     return 0;
 }
-"#).expect("write src");
+"#,
+    )
+    .expect("write src");
+
     let exe_path = dir.path().join("testprog");
+    let mut gcc_args: Vec<&str> = flags.to_vec();
+    gcc_args.push(src_path.to_str().unwrap());
+    gcc_args.push("-o");
+    gcc_args.push(exe_path.to_str().unwrap());
+
     let status = Command::new("gcc")
-        .args([
-            "-g",
-            "-O0",
-            src_path.to_str().unwrap(),
-            "-o",
-            exe_path.to_str().unwrap(),
-        ])
+        .args(&gcc_args)
         .status()
         .expect("compile test program");
     assert!(status.success());
@@ -47,60 +50,50 @@ int main() {
     let logdir = tempdir().expect("logdir");
     common::run_fuzmon_and_check(
         &["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()],
-        &["target_function", "main", "sleep", "testprog.c"],
+        expected,
     );
 
     let _ = child.kill();
     let _ = child.wait();
+}
+
+#[test]
+fn symbolized_stack_trace_contains_function() {
+    run_symbol_test(
+        &["-g", "-O0"],
+        &["target_function", "main", "sleep", "testprog.c"],
+    );
 }
 
 
 #[test]
 fn symbolized_stack_trace_contains_function_no_pie() {
-    let dir = tempdir().expect("tempdir");
-    let src_path = dir.path().join("testprog.c");
-    fs::write(&src_path, r#"
-#include <unistd.h>
-
-void target_function() {
-    while (1) {
-        sleep(1);
-    }
-}
-
-int main() {
-    target_function();
-    return 0;
-}
-"#).expect("write src");
-    let exe_path = dir.path().join("testprog");
-    let status = Command::new("gcc")
-        .args([
-            "-g",
-            "-O0",
-            "-no-pie",
-            src_path.to_str().unwrap(),
-            "-o",
-            exe_path.to_str().unwrap(),
-        ])
-        .status()
-        .expect("compile test program");
-    assert!(status.success());
-
-    let mut child = Command::new(&exe_path)
-        .stdout(Stdio::null())
-        .spawn()
-        .expect("spawn test program");
-
-    thread::sleep(Duration::from_millis(500));
-
-    let pid = child.id();
-    let logdir = tempdir().expect("logdir");
-    common::run_fuzmon_and_check(
-        &["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()],
+    run_symbol_test(
+        &["-g", "-O0", "-no-pie"],
         &["target_function", "main", "sleep", "testprog.c"],
     );
+}
 
-    let _ = child.kill();
-    let _ = child.wait();
+#[test]
+fn symbolized_stack_trace_contains_function_no_debug() {
+    run_symbol_test(
+        &["-O0"],
+        &["target_function", "main", "sleep"],
+    );
+}
+
+#[test]
+fn symbolized_stack_trace_contains_function_g1() {
+    run_symbol_test(
+        &["-g1", "-O0"],
+        &["target_function", "main", "sleep", "testprog.c"],
+    );
+}
+
+#[test]
+fn symbolized_stack_trace_contains_function_O2() {
+    run_symbol_test(
+        &["-g", "-O2"],
+        &["target_function", "main", "sleep", "testprog.c"],
+    );
 }


### PR DESCRIPTION
## Summary
- deduplicate symbol stack trace tests via `run_symbol_test`
- test stack trace symbolization with `gcc` flags: no debug info, `-g1`, and `-O2`

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684e4b41e5788322b2fb8645e54918ae