### PR TITLE
Implement subcommand interface for fuzmon

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,8 @@ mod config;
 mod procinfo;
 mod stacktrace;
 
-use crate::config::{parse_args, load_config, merge_config, uid_from_name, CmdArgs};
+use crate::config::{parse_cli, load_config, merge_config, uid_from_name, Cli, Commands, RunArgs};
+use clap::CommandFactory;
 use crate::procinfo::{
     read_pids, pid_uid, get_proc_usage, ProcState, should_suppress, process_name,
     proc_cpu_time_sec, proc_cpu_jiffies, vsz_kb, swap_kb, detect_fd_events,
@@ -45,11 +46,19 @@ struct FdLogEvent {
 }
 
 fn main() {
-    let args = parse_args();
-    run(args);
+    let cli = parse_cli();
+    if let Some(cmd) = cli.command {
+        match cmd {
+            Commands::Run(args) => run(args),
+            Commands::Dump => println!("TODO!"),
+        }
+    } else {
+        Cli::command().print_help().unwrap();
+        println!();
+    }
 }
 
-fn run(args: CmdArgs) {
+fn run(args: RunArgs) {
     let config = args
         .config
         .as_deref()

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,0 +1,22 @@
+use std::process::Command;
+
+#[test]
+fn dump_outputs_todo() {
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .arg("dump")
+        .output()
+        .expect("run fuzmon dump");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("TODO!"));
+}
+
+#[test]
+fn help_subcommand_shows_usage() {
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .arg("help")
+        .output()
+        .expect("run fuzmon help");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("fuzmon"));
+    assert!(stdout.contains("run"));
+}

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -10,8 +10,11 @@ pub fn run_fuzmon_and_check(args: &[&str], expected: &[&str]) {
         .and_then(|i| args.get(i + 1))
         .expect("args must contain -o <dir>");
 
+    let mut cmd_args = vec!["run"];
+    cmd_args.extend_from_slice(args);
+
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args(args)
+        .args(&cmd_args)
         .stdout(Stdio::null())
         .spawn()
         .expect("run fuzmon");

--- a/tests/fd_events.rs
+++ b/tests/fd_events.rs
@@ -36,7 +36,7 @@ sys.stdin.readline()
 
     let logdir = tempdir().expect("logdir");
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args(["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()])
+        .args(["run", "-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()])
         .stdout(Stdio::null())
         .spawn()
         .expect("run fuzmon");

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -32,7 +32,7 @@ if __name__ == '__main__':
 
     let logdir = tempdir().expect("logdir");
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args(["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()])
+        .args(["run", "-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()])
         .stdout(Stdio::null())
         .spawn()
         .expect("run fuzmon");


### PR DESCRIPTION
## Summary
- change CLI to use subcommands via clap
- support `run`, `dump`, and default help output
- update main entry point to match
- update tests for new interface and add CLI tests

## Testing
- `cargo test --quiet`
- `cargo check --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e57280f8883228c51303a228d2f43