### PR TITLE
Implement dump command and revise log extensions

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -14,7 +14,13 @@ pub enum Commands {
     /// Run the monitor
     Run(RunArgs),
     /// Dump logs
-    Dump,
+    Dump(DumpArgs),
+}
+
+#[derive(Parser, Clone)]
+pub struct DumpArgs {
+    /// Path to log file or directory
+    pub path: String,
 }
 
 #[derive(Parser, Default, Clone)]

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -1,13 +1,21 @@
 use std::process::Command;
+use tempfile::tempdir;
+use std::fs;
+
 
 #[test]
-fn dump_outputs_todo() {
+fn dump_outputs_entries() {
+    let dir = tempdir().expect("tempdir");
+    let log_path = dir.path().join("1.jsonl");
+    fs::write(&log_path, "{\"timestamp\":\"0\",\"pid\":1,\"process_name\":\"t\",\"cpu_time_sec\":0,\"memory\":{\"rss_kb\":0,\"vsz_kb\":0,\"swap_kb\":0}}\n").unwrap();
+
     let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .arg("dump")
+        .args(["dump", log_path.to_str().unwrap()])
         .output()
         .expect("run fuzmon dump");
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("TODO!"));
+    assert!(stdout.contains("1.jsonl"));
+    assert!(stdout.contains("process_name"));
 }
 
 #[test]

--- a/tests/fd_events.rs
+++ b/tests/fd_events.rs
@@ -41,7 +41,7 @@ sys.stdin.readline()
         .spawn()
         .expect("run fuzmon");
 
-    let log_path = logdir.path().join(format!("{}.log", pid));
+    let log_path = logdir.path().join(format!("{}.jsonl", pid));
     for _ in 0..50 {
         if log_path.exists() {
             break;

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -44,7 +44,7 @@ if __name__ == '__main__':
     let _ = child.kill();
     let _ = child.wait();
 
-    let log_path = logdir.path().join(format!("{}.log", pid));
+    let log_path = logdir.path().join(format!("{}.jsonl", pid));
     let log = fs::read_to_string(log_path).expect("read log");
     assert!(log.contains("foo"), "{}", log);
     assert!(log.contains("bar"), "{}", log);


### PR DESCRIPTION
## Summary
- switch log file names to use `.jsonl` or `.msgs` plus optional `.zst`
- implement `dump` subcommand to show log contents
- derive `Deserialize` and `Debug` for log structs
- update CLI and tests to use new extension and command

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e5be8b2708322b39835464cf581c9