### PR TITLE
Add daemon config example

### DIFF
--- a/examples/daemon.toml
+++ b/examples/daemon.toml
@@ -1,0 +1,10 @@
+# Recommended settings when running fuzmon as a daemon
+
+[output]
+format = "msgpack"
+path = "/var/log/fuzmon/"
+compress = true
+
+[monitor]
+interval_sec = 60
+cpu_time_jiffies_threshold = 1  # record when CPU usage exceeds 1%


### PR DESCRIPTION
## Summary
- add recommended settings for running as a daemon in examples/daemon.toml

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e6084452083229f00b6a2d9f01fd9