### PR TITLE
Support python and C traces per thread

### DIFF
--- a/tests/multi_thread.rs
+++ b/tests/multi_thread.rs
@@ -107,9 +107,9 @@ int main() {
     };
     let line = log.lines().next().expect("line");
     let entry: Value = serde_json::from_str(line).expect("json");
-    let stack = entry
-        .get("stacktrace")
+    let threads = entry
+        .get("threads")
         .and_then(|v| v.as_array())
         .expect("array");
-    assert!(stack.len() >= 2, "len {}", stack.len());
+    assert!(threads.len() >= 2, "len {}", threads.len());
 }

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -80,4 +80,19 @@ if __name__ == '__main__':
     assert!(log.contains("foo"), "{}", log);
     assert!(log.contains("bar"), "{}", log);
     assert!(log.contains("test.py"), "{}", log);
+    let first = log.lines().next().expect("line");
+    let entry: serde_json::Value = serde_json::from_str(first).expect("json");
+    let threads = entry.get("threads").and_then(|v| v.as_array()).expect("threads");
+    let mut has_c = false;
+    let mut has_py = false;
+    for t in threads {
+        if t.get("stacktrace").is_some() {
+            has_c = true;
+        }
+        if t.get("python_stacktrace").is_some() {
+            has_py = true;
+        }
+    }
+    assert!(has_c, "no c stacktrace: {}", first);
+    assert!(has_py, "no python stacktrace: {}", first);
 }


### PR DESCRIPTION
## Summary
- keep C and Python stack traces per-thread in log entries
- add `ThreadInfo` with `tid`, `stacktrace`, and `python_stacktrace`
- record Python traces alongside C traces in `build_log_entry`
- update multi-thread and python stack tests for new format

## Testing
- `cargo test --no-run`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_e_684e73718bc8832296af85a99850e006