### PR TITLE
Add helper for waiting for logs in tests

### DIFF
--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,30 +1,44 @@
 use std::process::{Command, Stdio};
 use std::{thread, time::Duration};
 use std::fs;
+use tempfile::TempDir;
 use zstd::stream;
 
 #[allow(dead_code)]
-pub fn run_fuzmon_and_check(args: &[&str], expected: &[&str]) {
-    let log_dir = args.iter()
-        .position(|&a| a == "-o")
-        .and_then(|i| args.get(i + 1))
-        .expect("args must contain -o <dir>");
+pub fn wait_until_file_appears(logdir: &TempDir, pid: u32) {
+    thread::sleep(Duration::from_millis(800));
+    let plain = logdir.path().join(format!("{pid}.jsonl"));
+    let zst = logdir.path().join(format!("{pid}.jsonl.zst"));
+    for _ in 0..80 {
+        if plain.exists() || zst.exists() {
+            break;
+        }
+        thread::sleep(Duration::from_millis(10));
+    }
+}
 
-    let mut cmd_args = vec!["run"];
-    cmd_args.extend_from_slice(args);
+#[allow(dead_code)]
+pub fn run_fuzmon_and_check(pid: u32, log_dir: &TempDir, expected: &[&str]) {
+    let pid_s = pid.to_string();
 
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args(&cmd_args)
+        .args([
+            "run",
+            "-p",
+            &pid_s,
+            "-o",
+            log_dir.path().to_str().unwrap(),
+        ])
         .stdout(Stdio::null())
         .spawn()
         .expect("run fuzmon");
 
-    thread::sleep(Duration::from_millis(800));
+    wait_until_file_appears(log_dir, pid);
     let _ = mon.kill();
     let _ = mon.wait();
 
     let mut log_content = String::new();
-    for entry in fs::read_dir(log_dir).expect("read_dir") {
+    for entry in fs::read_dir(log_dir.path()).expect("read_dir") {
         let path = entry.expect("entry").path();
         if let Some(ext) = path.extension() {
             if ext == "zst" {

--- a/tests/output_format.rs
+++ b/tests/output_format.rs
@@ -45,15 +45,7 @@ fn run_with_format(fmt: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         .spawn()
         .expect("run fuzmon");
 
-    thread::sleep(Duration::from_millis(800));
-    let plain = logdir.path().join(format!("{}.jsonl", pid));
-    let zst = logdir.path().join(format!("{}.jsonl.zst", pid));
-    for _ in 0..80 {
-        if plain.exists() || zst.exists() {
-            break;
-        }
-        thread::sleep(Duration::from_millis(10));
-    }
+    common::wait_until_file_appears(&logdir, pid);
     let _ = mon.kill();
     let _ = mon.wait();
 
@@ -91,15 +83,7 @@ fn run_default() -> (tempfile::TempDir, std::path::PathBuf) {
         .spawn()
         .expect("run fuzmon");
 
-    thread::sleep(Duration::from_millis(800));
-    let plain = logdir.path().join(format!("{}.jsonl", pid));
-    let zst = logdir.path().join(format!("{}.jsonl.zst", pid));
-    for _ in 0..80 {
-        if plain.exists() || zst.exists() {
-            break;
-        }
-        thread::sleep(Duration::from_millis(10));
-    }
+    common::wait_until_file_appears(&logdir, pid);
     let _ = mon.kill();
     let _ = mon.wait();
 

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use std::{thread, time::Duration};
 use tempfile::tempdir;
+mod common;
 
 #[test]
 fn python_stack_trace_contains_functions() {
@@ -49,15 +50,7 @@ if __name__ == '__main__':
         .spawn()
         .expect("run fuzmon");
 
-    thread::sleep(Duration::from_millis(800));
-    let plain = logdir.path().join(format!("{}.jsonl", pid));
-    let zst = logdir.path().join(format!("{}.jsonl.zst", pid));
-    for _ in 0..80 {
-        if plain.exists() || zst.exists() {
-            break;
-        }
-        thread::sleep(Duration::from_millis(10));
-    }
+    common::wait_until_file_appears(&logdir, pid);
     let _ = mon.kill();
     let _ = mon.wait();
 

--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -63,10 +63,7 @@ int main() {
 
     let pid = child.id();
     let logdir = tempdir().expect("logdir");
-    common::run_fuzmon_and_check(
-        &["-p", &pid.to_string(), "-o", logdir.path().to_str().unwrap()],
-        expected,
-    );
+    common::run_fuzmon_and_check(pid, &logdir, expected);
 
     let _ = child.kill();
     let _ = child.wait();


### PR DESCRIPTION
## Summary
- factor out log wait logic into `wait_until_file_appears`
- update `run_fuzmon_and_check` to accept pid and log dir
- use the new helper in python, symbols, and output format tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684e7bf6bc9c8322a5b0eb064ef44388