### PR TITLE
Handle SIGINT gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -529,6 +529,7 @@ dependencies = [
  "addr2line 0.25.0",
  "chrono",
  "clap 4.5.40",
+ "ctrlc",
  "env_logger 0.10.2",
  "log",
  "memmap2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ clap = { version = "4", features = ["derive"] }
 zstd = "0.13"
 log = "0.4"
 env_logger = "0.10"
+ctrlc = "3"
 
 [dev-dependencies]
 tempfile = "3"

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -34,7 +34,9 @@ pub fn run_fuzmon_and_check(pid: u32, log_dir: &TempDir, expected: &[&str]) {
         .expect("run fuzmon");
 
     wait_until_file_appears(log_dir, pid);
-    let _ = mon.kill();
+    unsafe {
+        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
+    }
     let _ = mon.wait();
 
     let mut log_content = String::new();

--- a/tests/fd_events.rs
+++ b/tests/fd_events.rs
@@ -107,7 +107,9 @@ sys.stdin.readline()
     drop(child_in);
 
     let _ = child.wait();
-    let _ = mon.kill();
+    unsafe {
+        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
+    }
     let _ = mon.wait();
 
     let path = if plain.exists() { &plain } else { &zst };

--- a/tests/multi_thread.rs
+++ b/tests/multi_thread.rs
@@ -86,7 +86,9 @@ int main() {
         .expect("run");
 
     thread::sleep(Duration::from_millis(800));
-    let _ = mon.kill();
+    unsafe {
+        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
+    }
     let _ = mon.wait();
 
     child_in.write_all(b"\n").unwrap();

--- a/tests/output_format.rs
+++ b/tests/output_format.rs
@@ -46,10 +46,14 @@ fn run_with_format(fmt: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         .expect("run fuzmon");
 
     common::wait_until_file_appears(&logdir, pid);
-    let _ = mon.kill();
+    unsafe {
+        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
+    }
     let _ = mon.wait();
 
-    let _ = child.kill();
+    unsafe {
+        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
+    }
     let _ = child.wait();
 
     let path = fs::read_dir(logdir.path())
@@ -84,10 +88,14 @@ fn run_default() -> (tempfile::TempDir, std::path::PathBuf) {
         .expect("run fuzmon");
 
     common::wait_until_file_appears(&logdir, pid);
-    let _ = mon.kill();
+    unsafe {
+        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
+    }
     let _ = mon.wait();
 
-    let _ = child.kill();
+    unsafe {
+        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
+    }
     let _ = child.wait();
 
     let path = fs::read_dir(logdir.path())

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -51,7 +51,9 @@ if __name__ == '__main__':
         .expect("run fuzmon");
 
     common::wait_until_file_appears(&logdir, pid);
-    let _ = mon.kill();
+    unsafe {
+        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
+    }
     let _ = mon.wait();
 
     child_in.write_all(b"\n").unwrap();

--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -65,7 +65,9 @@ int main() {
     let logdir = tempdir().expect("logdir");
     common::run_fuzmon_and_check(pid, &logdir, expected);
 
-    let _ = child.kill();
+    unsafe {
+        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
+    }
     let _ = child.wait();
 }
 


### PR DESCRIPTION
## Summary
- exit after the current iteration when SIGINT is received
- poll sleep in 100ms steps so SIGINT interrupts waiting
- add ctrlc dependency for signal handling
- adjust tests to send SIGINT instead of SIGKILL

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e864c87488322ac97238a4f9d0ad6