### PR TITLE
Switch to CPU percent threshold for skipping

### DIFF
--- a/ai_docs/DESIGN.md
+++ b/ai_docs/DESIGN.md
@@ -14,7 +14,7 @@
   - Include rules (e.g., user, memory usage)
   - **Automatically skip ptrace for "inactive" processes** based on:
     - CPU usage time (read from `/proc/<pid>/stat`)
-    - Threshold: e.g., total CPU time in jiffies < N
+    - Threshold: e.g., CPU usage percentage < N
 
 
 ### Stack Trace Collection

--- a/ai_docs/example_config.toml
+++ b/ai_docs/example_config.toml
@@ -10,4 +10,4 @@ compress = true
 
 [monitor]
 interval_sec = 60
-cpu_time_jiffies_threshold = 1
+cpu_time_percent_threshold = 1.0

--- a/examples/daemon.toml
+++ b/examples/daemon.toml
@@ -7,4 +7,4 @@ compress = true
 
 [monitor]
 interval_sec = 60
-cpu_time_jiffies_threshold = 1  # record when CPU usage exceeds 1%
+cpu_time_percent_threshold = 1.0  # record when CPU usage exceeds 1%

--- a/src/config.rs
+++ b/src/config.rs
@@ -65,7 +65,7 @@ pub struct MonitorConfig {
     #[serde(default)]
     pub interval_sec: Option<u64>,
     #[serde(default)]
-    pub cpu_time_jiffies_threshold: Option<u64>,
+    pub cpu_time_percent_threshold: Option<f64>,
 }
 
 #[derive(Default, Deserialize)]
@@ -111,8 +111,8 @@ pub fn merge_config(mut cfg: Config, args: &RunArgs) -> Config {
     if cfg.output.compress.is_none() {
         cfg.output.compress = Some(true);
     }
-    if cfg.monitor.cpu_time_jiffies_threshold.is_none() {
-        cfg.monitor.cpu_time_jiffies_threshold = Some(1);
+    if cfg.monitor.cpu_time_percent_threshold.is_none() {
+        cfg.monitor.cpu_time_percent_threshold = Some(1.0);
     }
     cfg
 }
@@ -134,7 +134,7 @@ mod tests {
         assert_eq!(cfg.output.path.as_deref(), Some("/var/log/fuzmon/"));
         assert_eq!(cfg.output.compress, Some(true));
         assert_eq!(cfg.monitor.interval_sec, Some(60));
-        assert_eq!(cfg.monitor.cpu_time_jiffies_threshold, Some(1));
+        assert_eq!(cfg.monitor.cpu_time_percent_threshold, Some(1.0));
         assert_eq!(cfg.filter.target_user.as_deref(), Some("myname"));
     }
 
@@ -164,6 +164,6 @@ mod tests {
         let merged = merge_config(cfg, &args);
         assert_eq!(merged.output.path.as_deref(), Some("/tmp/fuzmon"));
         assert_eq!(merged.output.compress, Some(true));
-        assert_eq!(merged.monitor.cpu_time_jiffies_threshold, Some(1));
+        assert_eq!(merged.monitor.cpu_time_percent_threshold, Some(1.0));
     }
 }

--- a/src/procinfo.rs
+++ b/src/procinfo.rs
@@ -1,8 +1,8 @@
+use log::warn;
+use nix::libc;
+use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
-use std::collections::HashMap;
-use nix::libc;
-use log::warn;
 
 #[derive(Default)]
 pub struct ProcState {
@@ -52,6 +52,7 @@ fn read_proc_stat(pid: u32) -> Option<(u64, u64)> {
     Some((utime, stime))
 }
 
+#[allow(dead_code)]
 pub fn proc_cpu_jiffies(pid: u32) -> Option<u64> {
     let (u, s) = read_proc_stat(pid)?;
     Some(u + s)
@@ -177,7 +178,7 @@ fn read_total_cpu_time() -> Option<u64> {
     Some(total)
 }
 
-fn read_rss_kb(pid: u32) -> Option<u64> {
+pub fn rss_kb(pid: u32) -> Option<u64> {
     let status = match fs::read_to_string(format!("/proc/{}/status", pid)) {
         Ok(s) => s,
         Err(e) => {
@@ -213,7 +214,7 @@ pub fn get_proc_usage(pid: u32, state: &mut ProcState) -> Option<(f32, u64)> {
         return None;
     }
     let cpu = 100.0 * delta_proc as f32 / delta_total as f32;
-    let rss = read_rss_kb(pid).unwrap_or(0);
+    let rss = rss_kb(pid).unwrap_or(0);
     Some((cpu, rss))
 }
 


### PR DESCRIPTION
## Summary
- update MonitorConfig to use `cpu_time_percent_threshold`
- always update `ProcState` and skip PID based on CPU usage
- expose `rss_kb` from procinfo
- adjust configs and design docs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e8d3ed9288322ada95f5ad5b0d0f1