### PR TITLE
Handle config parse errors

### DIFF
--- a/ai_docs/example_config.toml
+++ b/ai_docs/example_config.toml
@@ -5,7 +5,6 @@ target_user = "myname"
 [output]
 format = "json"              # or "msgpack"
 path = "/var/log/fuzmon/"
-rotate = true
 compress = true
 
 [monitor]

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,13 +83,7 @@ fn main() {
 
 fn run(args: RunArgs) {
     let config = match args.config.as_deref() {
-        Some(path) => match load_config(path) {
-            Ok(cfg) => cfg,
-            Err(e) => {
-                warn!("{}", e);
-                Config::default()
-            }
-        },
+        Some(path) => load_config(path),
         None => Config::default(),
     };
     let config = merge_config(config, &args);


### PR DESCRIPTION
## Summary
- enforce `deny_unknown_fields` for all config structs
- make `load_config` panic on error and log a warning
- update example config
- simplify CLI's config loading logic
- test for invalid/unknown fields

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_e_684e98a414e883229a35b61e4f8ad2e7