### PR TITLE
Update stacktrace threshold default

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -128,7 +128,7 @@ pub fn merge_config(mut cfg: Config, args: &RunArgs) -> Config {
         cfg.monitor.record_cpu_time_percent_threshold = Some(0.0);
     }
     if cfg.monitor.stacktrace_cpu_time_percent_threshold.is_none() {
-        cfg.monitor.stacktrace_cpu_time_percent_threshold = Some(0.0);
+        cfg.monitor.stacktrace_cpu_time_percent_threshold = Some(1.0);
     }
     cfg
 }
@@ -184,7 +184,7 @@ mod tests {
         assert_eq!(merged.monitor.record_cpu_time_percent_threshold, Some(0.0));
         assert_eq!(
             merged.monitor.stacktrace_cpu_time_percent_threshold,
-            Some(0.0)
+            Some(1.0)
         );
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,7 +135,7 @@ fn run(args: RunArgs) {
     let stacktrace_cpu_percent_threshold = config
         .monitor
         .stacktrace_cpu_time_percent_threshold
-        .unwrap_or(0.0);
+        .unwrap_or(1.0);
 
     let term = Arc::new(AtomicBool::new(false));
     {

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -1,7 +1,7 @@
 use std::fs;
 use std::process::{Command, Stdio};
 use std::{thread, time::Duration};
-use tempfile::TempDir;
+use tempfile::{NamedTempFile, TempDir};
 use zstd::stream;
 
 #[allow(dead_code)]
@@ -20,8 +20,23 @@ pub fn wait_until_file_appears(logdir: &TempDir, pid: u32) {
 pub fn run_fuzmon_and_check(pid: u32, log_dir: &TempDir, expected: &[&str]) {
     let pid_s = pid.to_string();
 
+    let cfg_file = NamedTempFile::new().expect("cfg");
+    fs::write(
+        cfg_file.path(),
+        "[monitor]\nstacktrace_cpu_time_percent_threshold = 0.0",
+    )
+    .expect("write cfg");
+
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args(["run", "-p", &pid_s, "-o", log_dir.path().to_str().unwrap()])
+        .args([
+            "run",
+            "-p",
+            &pid_s,
+            "-o",
+            log_dir.path().to_str().unwrap(),
+            "-c",
+            cfg_file.path().to_str().unwrap(),
+        ])
         .stdout(Stdio::null())
         .spawn()
         .expect("run fuzmon");

--- a/tests/common.rs
+++ b/tests/common.rs
@@ -17,15 +17,24 @@ pub fn wait_until_file_appears(logdir: &TempDir, pid: u32) {
 }
 
 #[allow(dead_code)]
-pub fn run_fuzmon_and_check(pid: u32, log_dir: &TempDir, expected: &[&str]) {
-    let pid_s = pid.to_string();
-
+pub fn create_config(threshold: f64) -> NamedTempFile {
     let cfg_file = NamedTempFile::new().expect("cfg");
     fs::write(
         cfg_file.path(),
-        "[monitor]\nstacktrace_cpu_time_percent_threshold = 0.0",
+        format!(
+            "[monitor]\nstacktrace_cpu_time_percent_threshold = {}",
+            threshold
+        ),
     )
     .expect("write cfg");
+    cfg_file
+}
+
+#[allow(dead_code)]
+pub fn run_fuzmon_and_check(pid: u32, log_dir: &TempDir, expected: &[&str]) {
+    let pid_s = pid.to_string();
+
+    let cfg_file = create_config(0.0);
 
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args([

--- a/tests/multi_thread.rs
+++ b/tests/multi_thread.rs
@@ -72,6 +72,13 @@ int main() {
     let pid = child.id();
 
     let logdir = tempdir().expect("logdir");
+    let cfg_file = tempfile::NamedTempFile::new().expect("cfg");
+    std::fs::write(
+        cfg_file.path(),
+        "[monitor]\nstacktrace_cpu_time_percent_threshold = 0.0",
+    )
+    .expect("write cfg");
+
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args([
             "run",
@@ -79,6 +86,8 @@ int main() {
             &pid.to_string(),
             "-o",
             logdir.path().to_str().unwrap(),
+            "-c",
+            cfg_file.path().to_str().unwrap(),
         ])
         .stdout(Stdio::null())
         .spawn()

--- a/tests/multi_thread.rs
+++ b/tests/multi_thread.rs
@@ -4,6 +4,7 @@ use std::io::Write;
 use std::process::{Command, Stdio};
 use std::{thread, time::Duration};
 use tempfile::tempdir;
+mod common;
 
 #[test]
 fn multi_thread_stacktrace_has_multiple_entries() {
@@ -72,12 +73,7 @@ int main() {
     let pid = child.id();
 
     let logdir = tempdir().expect("logdir");
-    let cfg_file = tempfile::NamedTempFile::new().expect("cfg");
-    std::fs::write(
-        cfg_file.path(),
-        "[monitor]\nstacktrace_cpu_time_percent_threshold = 0.0",
-    )
-    .expect("write cfg");
+    let cfg_file = common::create_config(0.0);
 
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args([

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -38,12 +38,7 @@ if __name__ == '__main__':
     let pid = child.id();
 
     let logdir = tempdir().expect("logdir");
-    let cfg_file = tempfile::NamedTempFile::new().expect("cfg");
-    std::fs::write(
-        cfg_file.path(),
-        "[monitor]\nstacktrace_cpu_time_percent_threshold = 0.0",
-    )
-    .expect("write cfg");
+    let cfg_file = common::create_config(0.0);
 
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args([

--- a/tests/python_stack.rs
+++ b/tests/python_stack.rs
@@ -38,6 +38,13 @@ if __name__ == '__main__':
     let pid = child.id();
 
     let logdir = tempdir().expect("logdir");
+    let cfg_file = tempfile::NamedTempFile::new().expect("cfg");
+    std::fs::write(
+        cfg_file.path(),
+        "[monitor]\nstacktrace_cpu_time_percent_threshold = 0.0",
+    )
+    .expect("write cfg");
+
     let mut mon = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args([
             "run",
@@ -45,6 +52,8 @@ if __name__ == '__main__':
             &pid.to_string(),
             "-o",
             logdir.path().to_str().unwrap(),
+            "-c",
+            cfg_file.path().to_str().unwrap(),
         ])
         .stdout(Stdio::null())
         .spawn()


### PR DESCRIPTION
## Summary
- set `stacktrace_cpu_time_percent_threshold` default to `1.0`
- adjust tests to specify a config overriding the threshold

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684e9e27d6a88322ac944a9f010827c3