### PR TITLE
Record CPU percent in logs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each line in the log file is a JSON object similar to:
   "timestamp": "2025-06-14T14:23:51Z",
   "pid": 12345,
   "process_name": "python3",
-  "cpu_time_sec": 12.3,
+  "cpu_time_percent": 12.3,
   "memory": { "rss_kb": 20480, "vsz_kb": 105000, "swap_kb": 0 },
   "stacktrace": [[" 0: 0xdeadbeef main at main.c:42"]]
 }

--- a/ai_docs/DESIGN.md
+++ b/ai_docs/DESIGN.md
@@ -53,7 +53,7 @@
   "timestamp": "2025-06-14T14:23:51Z",
   "pid": 12345,
   "process_name": "python3",
-  "cpu_time_sec": 12.3,
+  "cpu_time_percent": 12.3,
   "memory": {
     "rss_kb": 20480,
     "vsz_kb": 105000,

--- a/src/procinfo.rs
+++ b/src/procinfo.rs
@@ -1,5 +1,4 @@
 use log::warn;
-use nix::libc;
 use std::collections::HashMap;
 use std::fs;
 use std::os::unix::fs::MetadataExt;
@@ -144,16 +143,6 @@ pub fn vsz_kb(pid: u32) -> Option<u64> {
 
 pub fn swap_kb(pid: u32) -> Option<u64> {
     read_status_value(pid, "VmSwap:")
-}
-
-pub fn proc_cpu_time_sec(pid: u32) -> Option<f64> {
-    let (u, s) = read_proc_stat(pid)?;
-    let clk = unsafe { libc::sysconf(libc::_SC_CLK_TCK) } as f64;
-    if clk > 0.0 {
-        Some((u + s) as f64 / clk)
-    } else {
-        None
-    }
 }
 
 fn read_total_cpu_time() -> Option<u64> {

--- a/tests/cli.rs
+++ b/tests/cli.rs
@@ -6,7 +6,7 @@ use tempfile::tempdir;
 fn dump_outputs_entries() {
     let dir = tempdir().expect("tempdir");
     let log_path = dir.path().join("1.jsonl");
-    fs::write(&log_path, "{\"timestamp\":\"0\",\"pid\":1,\"process_name\":\"t\",\"cpu_time_sec\":0,\"memory\":{\"rss_kb\":0,\"vsz_kb\":0,\"swap_kb\":0}}\n").unwrap();
+    fs::write(&log_path, "{\"timestamp\":\"0\",\"pid\":1,\"process_name\":\"t\",\"cpu_time_percent\":0,\"memory\":{\"rss_kb\":0,\"vsz_kb\":0,\"swap_kb\":0}}\n").unwrap();
 
     let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args(["dump", log_path.to_str().unwrap()])


### PR DESCRIPTION
## Summary
- replace `cpu_time_sec` field with `cpu_time_percent` in logs
- write CPU percent in `build_log_entry`
- drop unused `proc_cpu_time_sec` helper
- update documentation and tests

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ecc42ba6c8322aa4d224fca6c9b81