### PR TITLE
Exit when monitored pid disappears

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -176,6 +176,12 @@ fn run(args: RunArgs) {
 
     let mut states: HashMap<u32, ProcState> = HashMap::new();
     loop {
+        if let Some(pid) = target_pid {
+            if !procinfo::proc_exists(pid) {
+                println!("終了します");
+                break;
+            }
+        }
         monitor_iteration(
             &mut states,
             target_pid,

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,8 +25,8 @@ use crate::config::{
     Cli, Commands, Config, RunArgs, load_config, merge_config, parse_cli, uid_from_name,
 };
 use crate::procinfo::{
-    ProcState, detect_fd_events, get_proc_usage, pid_uid, process_name, read_pids, rss_kb,
-    should_suppress, swap_kb, vsz_kb,
+    ProcState, detect_fd_events, get_proc_usage, pid_uid, proc_exists, process_name, read_pids,
+    rss_kb, should_suppress, swap_kb, vsz_kb,
 };
 use crate::stacktrace::{capture_c_stack_traces, capture_python_stack_traces};
 use clap::CommandFactory;
@@ -177,8 +177,11 @@ fn run(args: RunArgs) {
     let mut states: HashMap<u32, ProcState> = HashMap::new();
     loop {
         if let Some(pid) = target_pid {
-            if !procinfo::proc_exists(pid) {
-                println!("終了します");
+            if !proc_exists(pid) {
+                let name = process_name(pid).unwrap_or_else(|| "?".to_string());
+                let msg = format!("Process {pid} ({name}) disappeared, exiting");
+                println!("{}", msg);
+                info!("{}", msg);
                 break;
             }
         }

--- a/src/procinfo.rs
+++ b/src/procinfo.rs
@@ -28,6 +28,19 @@ pub fn pid_uid(pid: u32) -> Option<u32> {
     }
 }
 
+pub fn proc_exists(pid: u32) -> bool {
+    match fs::read_to_string(format!("/proc/{}/stat", pid)) {
+        Ok(data) => {
+            let parts: Vec<&str> = data.split_whitespace().collect();
+            if let Some(state) = parts.get(2) {
+                return *state != "Z";
+            }
+            true
+        }
+        Err(_) => false,
+    }
+}
+
 pub fn read_pids() -> Vec<u32> {
     let mut pids = Vec::new();
     if let Ok(entries) = fs::read_dir("/proc") {

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -91,6 +91,26 @@ fn append_file(path: &std::path::Path, log_content: &mut String) {
     }
 }
 
+pub fn run_fuzmon_output(
+    bin: &str,
+    pid: u32,
+    log_dir: &TempDir,
+    cfg_file: &NamedTempFile,
+) -> std::process::Output {
+    Command::new(bin)
+        .args([
+            "run",
+            "-p",
+            &pid.to_string(),
+            "-o",
+            log_dir.path().to_str().unwrap(),
+            "-c",
+            cfg_file.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run fuzmon")
+}
+
 pub fn run_fuzmon_and_check(bin: &str, pid: u32, log_dir: &TempDir, expected: &[&str]) {
     let log_content = run_fuzmon(bin, pid, log_dir);
 

--- a/tests/pid_exit.rs
+++ b/tests/pid_exit.rs
@@ -1,4 +1,4 @@
-use fuzmon::test_utils::create_config;
+use fuzmon::test_utils::{create_config, run_fuzmon_output};
 use std::process::Command;
 use tempfile::tempdir;
 
@@ -12,20 +12,9 @@ fn exits_when_pid_disappears() {
 
     let logdir = tempdir().expect("logdir");
     let cfg = create_config(1000.0);
-    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
-        .args([
-            "run",
-            "-p",
-            &pid.to_string(),
-            "-o",
-            logdir.path().to_str().unwrap(),
-            "-c",
-            cfg.path().to_str().unwrap(),
-        ])
-        .output()
-        .expect("run fuzmon");
+    let out = run_fuzmon_output(env!("CARGO_BIN_EXE_fuzmon"), pid, &logdir, &cfg);
 
     let _ = child.wait();
     let stdout = String::from_utf8_lossy(&out.stdout);
-    assert!(stdout.contains("終了します"), "{}", stdout);
+    assert!(stdout.contains("disappeared, exiting"), "{}", stdout);
 }

--- a/tests/pid_exit.rs
+++ b/tests/pid_exit.rs
@@ -1,0 +1,31 @@
+use fuzmon::test_utils::create_config;
+use std::process::Command;
+use tempfile::tempdir;
+
+#[test]
+fn exits_when_pid_disappears() {
+    let mut child = Command::new("sleep")
+        .arg("0.2")
+        .spawn()
+        .expect("spawn sleep");
+    let pid = child.id();
+
+    let logdir = tempdir().expect("logdir");
+    let cfg = create_config(1000.0);
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .args([
+            "run",
+            "-p",
+            &pid.to_string(),
+            "-o",
+            logdir.path().to_str().unwrap(),
+            "-c",
+            cfg.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run fuzmon");
+
+    let _ = child.wait();
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("終了します"), "{}", stdout);
+}


### PR DESCRIPTION
## Summary
- exit the monitor when the target pid vanishes
- detect zombie processes when checking for pid existence
- test for the new behaviour

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ecbb7b8848322a0431be00eff2115