### PR TITLE
Implement date-based log subdirectories

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,9 @@ fuzmon -p 1234 -o logs/
 # logs default to /tmp/fuzmon when -o not specified
 ```
 
+Log files are written under a date directory such as `logs/20250615/`. A new
+directory is created if the date changes while running.
+
 Each line in the log file is a JSON object similar to:
 
 ```json

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,1 +1,2 @@
 pub mod test_utils;
+pub mod utils;

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,6 +30,7 @@ use crate::procinfo::{
 };
 use crate::stacktrace::{capture_c_stack_traces, capture_python_stack_traces};
 use clap::CommandFactory;
+use fuzmon::utils::current_date_string;
 
 #[derive(Serialize, Deserialize, Debug)]
 struct MemoryInfo {
@@ -392,8 +393,13 @@ fn build_log_entry(
 }
 
 fn write_log(dir: &str, entry: &LogEntry, use_msgpack: bool, compress: bool) {
+    let date = current_date_string();
+    let dir = format!("{}/{}", dir.trim_end_matches('/'), date);
+    if let Err(e) = fs::create_dir_all(&dir) {
+        warn!("failed to create {}: {}", dir, e);
+    }
     let ext = if use_msgpack { "msgpacks" } else { "jsonl" };
-    let base = format!("{}/{}.{}", dir.trim_end_matches('/'), entry.pid, ext);
+    let base = format!("{}/{}.{}", dir, entry.pid, ext);
     let path = if compress {
         format!("{}.zst", base)
     } else {

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,0 +1,6 @@
+use chrono::Utc;
+
+/// Returns current date as YYYYMMDD string in UTC.
+pub fn current_date_string() -> String {
+    Utc::now().format("%Y%m%d").to_string()
+}

--- a/tests/fd_events.rs
+++ b/tests/fd_events.rs
@@ -1,4 +1,5 @@
 use fuzmon::test_utils::wait_until_file_appears;
+use fuzmon::utils::current_date_string;
 use std::fs;
 use std::io::Write;
 use std::process::{Command, Stdio};
@@ -47,8 +48,10 @@ sys.stdin.readline()
         .spawn()
         .expect("run fuzmon");
 
-    let plain = logdir.path().join(format!("{}.jsonl", pid));
-    let zst = logdir.path().join(format!("{}.jsonl.zst", pid));
+    let date = current_date_string();
+    let base_dir = logdir.path().join(&date);
+    let plain = base_dir.join(format!("{}.jsonl", pid));
+    let zst = base_dir.join(format!("{}.jsonl.zst", pid));
     wait_until_file_appears(&logdir, pid);
 
     child_in.write_all(b"\n").unwrap();

--- a/tests/output_format.rs
+++ b/tests/output_format.rs
@@ -3,6 +3,7 @@ use std::process::{Command, Stdio};
 use tempfile::{NamedTempFile, tempdir};
 
 use fuzmon::test_utils::wait_until_file_appears;
+use fuzmon::utils::current_date_string;
 
 fn run_with_format(fmt: &str) -> (tempfile::TempDir, std::path::PathBuf) {
     let logdir = tempdir().expect("logdir");
@@ -54,7 +55,9 @@ fn run_with_format(fmt: &str) -> (tempfile::TempDir, std::path::PathBuf) {
     }
     let _ = child.wait();
 
-    let path = fs::read_dir(logdir.path())
+    let date = current_date_string();
+    let subdir = logdir.path().join(date);
+    let path = fs::read_dir(&subdir)
         .unwrap()
         .next()
         .unwrap()
@@ -95,7 +98,9 @@ fn run_default() -> (tempfile::TempDir, std::path::PathBuf) {
     }
     let _ = child.wait();
 
-    let path = fs::read_dir(logdir.path())
+    let date = current_date_string();
+    let subdir = logdir.path().join(date);
+    let path = fs::read_dir(&subdir)
         .unwrap()
         .next()
         .unwrap()


### PR DESCRIPTION
## Summary
- put logs under a daily directory named `YYYYMMDD`
- add helper to compute the current date
- update tests and utilities for new output layout
- document date directory behavior in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684ecce97a3c83229d844514a359f2ea