### PR TITLE
Add command execution mode and PID checks

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -41,6 +41,9 @@ pub struct RunArgs {
     /// Verbose output
     #[arg(short, long)]
     pub verbose: bool,
+    /// Command to run and monitor
+    #[arg(trailing_var_arg = true)]
+    pub command: Vec<String>,
 }
 
 #[derive(Default, Deserialize)]

--- a/src/test_utils.rs
+++ b/src/test_utils.rs
@@ -56,6 +56,10 @@ pub fn run_fuzmon(bin: &str, pid: u32, log_dir: &TempDir) -> String {
     }
     let _ = mon.wait();
 
+    collect_log_content(log_dir)
+}
+
+pub fn collect_log_content(log_dir: &TempDir) -> String {
     let mut log_content = String::new();
     for entry in fs::read_dir(log_dir.path()).expect("read_dir") {
         let path = entry.expect("entry").path();
@@ -68,7 +72,6 @@ pub fn run_fuzmon(bin: &str, pid: u32, log_dir: &TempDir) -> String {
             append_file(&path, &mut log_content);
         }
     }
-
     log_content
 }
 

--- a/tests/nonexistent_pid.rs
+++ b/tests/nonexistent_pid.rs
@@ -1,0 +1,14 @@
+use std::process::Command;
+use std::time::Instant;
+use tempfile::tempdir;
+
+#[test]
+fn nonexistent_pid_exits_immediately() {
+    let dir = tempdir().expect("dir");
+    let start = Instant::now();
+    Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .args(["run", "-p", "9999999", "-o", dir.path().to_str().unwrap()])
+        .output()
+        .expect("run");
+    assert!(start.elapsed().as_secs() < 2, "took {:?}", start.elapsed());
+}

--- a/tests/run_command.rs
+++ b/tests/run_command.rs
@@ -1,0 +1,30 @@
+use std::fs;
+use std::process::Command;
+use tempfile::tempdir;
+
+use fuzmon::test_utils::{collect_log_content, create_config};
+use fuzmon::utils::current_date_string;
+
+#[test]
+fn spawn_and_monitor_command() {
+    let dir = tempdir().expect("dir");
+    let cfg = create_config(0.0);
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .args([
+            "run",
+            "-o",
+            dir.path().to_str().unwrap(),
+            "-c",
+            cfg.path().to_str().unwrap(),
+            "/bin/sleep",
+            "1",
+        ])
+        .output()
+        .expect("run");
+    assert!(out.status.success());
+    let date = current_date_string();
+    let sub = dir.path().join(date);
+    let log_content = collect_log_content(&dir);
+    assert!(fs::read_dir(sub).unwrap().next().is_some(), "no log file");
+    assert!(!log_content.is_empty(), "log empty");
+}


### PR DESCRIPTION
## Summary
- allow `fuzmon run` to launch and monitor a command
- exit immediately when a specified PID does not exist
- refactor log helper in tests
- test for missing PID and command execution

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ed251d7fc8322a0057026323c51d4