### PR TITLE
Improve error messages for run command

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -133,7 +133,9 @@ fn run(args: RunArgs) {
                 info!("spawned {} as pid {}", args.command[0], target_pid.unwrap());
             }
             Err(e) => {
-                warn!("failed to spawn {}: {}", args.command[0], e);
+                let msg = format!("failed to spawn {}: {}", args.command[0], e);
+                println!("{}", msg);
+                warn!("{}", msg);
                 return;
             }
         }
@@ -141,7 +143,9 @@ fn run(args: RunArgs) {
 
     if let Some(pid) = target_pid {
         if fs::metadata(format!("/proc/{}", pid)).is_err() {
-            warn!("pid {} not found", pid);
+            let msg = format!("pid {} not found", pid);
+            println!("{}", msg);
+            warn!("{}", msg);
             return;
         }
     }

--- a/tests/nonexistent_pid.rs
+++ b/tests/nonexistent_pid.rs
@@ -6,9 +6,11 @@ use tempfile::tempdir;
 fn nonexistent_pid_exits_immediately() {
     let dir = tempdir().expect("dir");
     let start = Instant::now();
-    Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
         .args(["run", "-p", "9999999", "-o", dir.path().to_str().unwrap()])
         .output()
         .expect("run");
     assert!(start.elapsed().as_secs() < 2, "took {:?}", start.elapsed());
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("not found"), "{}", stdout);
 }

--- a/tests/spawn_failure.rs
+++ b/tests/spawn_failure.rs
@@ -1,0 +1,11 @@
+use std::process::Command;
+
+#[test]
+fn spawn_invalid_command_prints_message() {
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .args(["run", "/bin/hogeee"])
+        .output()
+        .expect("run");
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("failed to spawn"), "{}", stdout);
+}


### PR DESCRIPTION
## Summary
- handle spawn failures and missing PIDs with a printed warning
- test that nonexistent PID prints not-found message
- test that running an invalid command prints spawn failure message

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_e_684eda0e3fa88322b7577ed8ba160a21