### PR TITLE
Generate HTML reports in directory

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -33,6 +33,9 @@ pub struct ReportArgs {
     /// Path to configuration file
     #[arg(short = 'c', long)]
     pub config: Option<String>,
+    /// Output directory for HTML report
+    #[arg(short = 'o', long)]
+    pub output: Option<String>,
 }
 
 #[derive(Parser, Default, Clone)]


### PR DESCRIPTION
## Summary
- allow `fuzmon report` to write output into a directory via `-o`
- default output directory name uses the input path basename
- add per‐PID HTML files when processing a directory
- update tests for new directory based HTML reports

## Testing
- `cargo test --quiet html_report_has_stats -- --test-threads=1`
- `cargo test --quiet` *(fails: detect_fd_open_close)*

------
https://chatgpt.com/codex/tasks/task_e_684ee68a65b083228d98441a2e17e93f