### PR TITLE
Refactor test signal handling

### DIFF
--- a/tests/fd_events.rs
+++ b/tests/fd_events.rs
@@ -103,10 +103,7 @@ sys.stdin.readline()
     drop(child_in);
 
     let _ = child.wait();
-    unsafe {
-        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = mon.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut mon);
 
     let path = if plain.exists() { &plain } else { &zst };
     let log_content = if path.extension().and_then(|e| e.to_str()) == Some("zst") {

--- a/tests/metadata.rs
+++ b/tests/metadata.rs
@@ -14,10 +14,7 @@ fn first_entry_contains_cmdline_and_env() {
         .expect("spawn sleep");
     let pid = child.id();
     let log = run_fuzmon(env!("CARGO_BIN_EXE_fuzmon"), pid, &logdir);
-    unsafe {
-        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = child.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut child);
     let first = log.lines().next().expect("line");
     let v: Value = serde_json::from_str(first).expect("json");
     assert_eq!(v.get("cmdline").and_then(|s| s.as_str()), Some("sleep 1"));

--- a/tests/output_format.rs
+++ b/tests/output_format.rs
@@ -45,15 +45,9 @@ fn run_with_format(fmt: &str) -> (tempfile::TempDir, std::path::PathBuf) {
         .expect("run fuzmon");
 
     wait_until_file_appears(&logdir, pid);
-    unsafe {
-        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = mon.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut mon);
 
-    unsafe {
-        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = child.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut child);
 
     let date = current_date_string();
     let subdir = logdir.path().join(date);
@@ -88,15 +82,9 @@ fn run_default() -> (tempfile::TempDir, std::path::PathBuf) {
         .expect("run fuzmon");
 
     wait_until_file_appears(&logdir, pid);
-    unsafe {
-        let _ = nix::libc::kill(mon.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = mon.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut mon);
 
-    unsafe {
-        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = child.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut child);
 
     let date = current_date_string();
     let subdir = logdir.path().join(date);

--- a/tests/symbols.rs
+++ b/tests/symbols.rs
@@ -69,10 +69,7 @@ int main() {
     let logdir = tempdir().expect("logdir");
     run_fuzmon_and_check(env!("CARGO_BIN_EXE_fuzmon"), pid, &logdir, expected);
 
-    unsafe {
-        let _ = nix::libc::kill(child.id() as i32, nix::libc::SIGINT);
-    }
-    let _ = child.wait();
+    fuzmon::test_utils::kill_with_sigint_and_wait(&mut child);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- provide `kill_with_sigint_and_wait` helper
- use the helper in tests

## Testing
- `cargo test --quiet` *(fails: detect_fd_open_close)*

------
https://chatgpt.com/codex/tasks/task_e_684ee7d459b483228a277420ee813ac2