### PR TITLE
Add average CPU usage in report

### DIFF
--- a/tests/report.rs
+++ b/tests/report.rs
@@ -45,6 +45,7 @@ fn html_report_has_stats() {
     let html = fs::read_to_string(outdir.path().join("index.html")).unwrap();
     assert!(html.contains("Total runtime: 10"), "{}", html);
     assert!(html.contains("Total CPU time"), "{}", html);
+    assert!(html.contains("Average CPU usage"), "{}", html);
     assert!(html.contains("2000"), "{}", html);
     assert!(html.contains("REPORT_VAR"), "{}", html);
 }


### PR DESCRIPTION
## Summary
- compute average CPU usage for each process
- show average CPU usage in HTML report and index
- sort processes by CPU usage (values <=0.1 treated as 0) with peak RSS as tiebreaker
- check for the new output in tests

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684ef0e9ab4c83229e4af56e10ab9fb9