### PR TITLE
Fix CI missing fontconfig

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,16 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - uses: dtolnay/rust-toolchain@stable
+      - name: Cache apt packages
+        uses: actions/cache@v3
+        with:
+          path: |
+            /var/cache/apt/archives
+            /var/lib/apt/lists
+          key: ${{ runner.os }}-apt-${{ hashFiles('.github/workflows/ci.yml') }}
+          restore-keys: ${{ runner.os }}-apt-
       - name: Install build tools
-        run: sudo apt-get update && sudo apt-get install -y gcc libunwind-dev
+        run: sudo apt-get update && sudo apt-get install -y gcc libunwind-dev libfontconfig-dev
       - name: Allow ptrace
         run: sudo sysctl -w kernel.yama.ptrace_scope=0
       - name: Build


### PR DESCRIPTION
## Summary
- cache apt packages and install libfontconfig-dev

## Testing
- `cargo test -- --nocapture`

------
https://chatgpt.com/codex/tasks/task_e_684f3ad61f888322845caa00e946b9ca