### PR TITLE
Add Frame struct for detailed stack traces

### DIFF
--- a/src/log.rs
+++ b/src/log.rs
@@ -15,13 +15,25 @@ pub struct MemoryInfo {
     pub swap_kb: u64,
 }
 
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub struct Frame {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub addr: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub func: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub file: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub line: Option<i32>,
+}
+
 #[derive(Serialize, Deserialize, Debug)]
 pub struct ThreadInfo {
     pub tid: u32,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub stacktrace: Option<Vec<String>>,
+    pub stacktrace: Option<Vec<Frame>>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    pub python_stacktrace: Option<Vec<String>>,
+    pub python_stacktrace: Option<Vec<Frame>>,
 }
 
 #[derive(Serialize, Deserialize, Debug)]


### PR DESCRIPTION
## Summary
- add new `Frame` struct with optional fields
- store stack traces as `Option<Vec<Frame>>`
- update stack trace capturing and reporting
- include frame data as chrome trace args

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f3a8b8f1083228c29c71f7c05abb2