### PR TITLE
Collapse long command column in report index

### DIFF
--- a/src/report.rs
+++ b/src/report.rs
@@ -293,6 +293,18 @@ fn write_trace(entries: &[LogEntry], out_dir: &Path, pid: u32) {
     }
 }
 
+fn truncate(s: &str, len: usize) -> String {
+    let mut out = String::new();
+    for (i, c) in s.chars().enumerate() {
+        if i >= len {
+            out.push_str("...");
+            break;
+        }
+        out.push(c);
+    }
+    out
+}
+
 fn render_single(s: &Stats) -> String {
     let mut out = String::new();
     out.push_str("<html><body>\n");
@@ -328,7 +340,7 @@ fn render_single(s: &Stats) -> String {
 
 fn render_index(stats: &[Stats], link: bool) -> String {
     let mut out = String::new();
-    out.push_str("<html><body>\n");
+    out.push_str("<html><head><style>table,th,td{border:1px solid black;border-collapse:collapse;}pre{margin:0;}</style></head><body>\n");
     out.push_str("<table>\n");
     out.push_str(
         "<tr><th>PID</th><th>Command</th><th>Total runtime</th><th>Total CPU time</th><th>Avg CPU (%)</th><th>Peak RSS</th></tr>\n",
@@ -339,14 +351,15 @@ fn render_index(stats: &[Stats], link: bool) -> String {
         } else {
             s.pid.to_string()
         };
+        let summary = truncate(&s.cmd, 30);
+        let cmd_cell = format!(
+            "<details><summary>{}</summary><pre>{}</pre></details>",
+            encode_text(&summary),
+            encode_text(&s.cmd)
+        );
         out.push_str(&format!(
             "<tr><td>{}</td><td>{}</td><td>{}</td><td>{:.1}</td><td>{:.1}</td><td>{}</td></tr>\n",
-            pid_cell,
-            encode_text(&s.cmd),
-            s.runtime,
-            s.cpu,
-            s.avg_cpu,
-            s.peak_rss
+            pid_cell, cmd_cell, s.runtime, s.cpu, s.avg_cpu, s.peak_rss
         ));
     }
     out.push_str("</table></body></html>\n");

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -103,6 +103,32 @@ fn html_report_directory() {
 }
 
 #[test]
+fn command_column_collapsed() {
+    let dir = tempdir().expect("dir");
+    let log = dir.path().join("1234.jsonl");
+    fs::write(
+        &log,
+        "{\"timestamp\":\"2025-06-14T00:00:00Z\",\"pid\":1234,\"process_name\":\"a\",\"cpu_time_percent\":0.0,\"memory\":{\"rss_kb\":1000,\"vsz_kb\":0,\"swap_kb\":0},\"cmdline\":\"a very very long command line that should be collapsed\"}\n{\"timestamp\":\"2025-06-14T00:00:10Z\",\"pid\":1234,\"process_name\":\"a\",\"cpu_time_percent\":0.0,\"memory\":{\"rss_kb\":1000,\"vsz_kb\":0,\"swap_kb\":0}}\n",
+    )
+    .unwrap();
+
+    let outdir = tempdir().expect("outdir");
+    let out = Command::new(env!("CARGO_BIN_EXE_fuzmon"))
+        .args([
+            "report",
+            dir.path().to_str().unwrap(),
+            "-o",
+            outdir.path().to_str().unwrap(),
+        ])
+        .output()
+        .expect("run report dir");
+    assert!(out.status.success());
+    let html = fs::read_to_string(outdir.path().join("index.html")).unwrap();
+    assert!(html.contains("<details>"), "{}", html);
+    assert!(html.contains("border-collapse"), "{}", html);
+}
+
+#[test]
 fn trace_json_created_with_stacktrace() {
     use fuzmon::test_utils::run_fuzmon;
     use fuzmon::utils::current_date_string;


### PR DESCRIPTION
## Summary
- fold long commands using `<details>` in `report` index page
- add table borders for readability
- ensure command column collapse tested

## Testing
- `cargo fmt`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f3f5b63808322a12bfcd49dea0efc