### PR TITLE
Add aggregated CPU/RSS graphs to report index

### DIFF
--- a/tests/report.rs
+++ b/tests/report.rs
@@ -100,6 +100,10 @@ fn html_report_directory() {
     assert!(outdir.path().join("1111_rss.svg").exists());
     assert!(outdir.path().join("2222_cpu.svg").exists());
     assert!(outdir.path().join("2222_rss.svg").exists());
+    assert!(outdir.path().join("top_cpu.svg").exists());
+    assert!(outdir.path().join("top_rss.svg").exists());
+    assert!(html.contains("top_cpu.svg"), "{}", html);
+    assert!(html.contains("top_rss.svg"), "{}", html);
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- show graphs of top processes in index page
- generate `top_cpu.svg` and `top_rss.svg` from log data
- update tests for new graphs

## Testing
- `cargo check`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_e_684f5e750cec83228164bd7f6105fe6b