### PR TITLE
Improve report graphs with absolute timestamps

### DIFF
--- a/tests/report.rs
+++ b/tests/report.rs
@@ -91,6 +91,8 @@ fn html_report_directory() {
         stdout
     );
     let html = fs::read_to_string(outdir.path().join("index.html")).unwrap();
+    assert!(html.contains("Start:"), "{}", html);
+    assert!(html.contains("End:"), "{}", html);
     let pos1 = html.find("1111").expect("1111");
     let pos2 = html.find("2222").expect("2222");
     assert!(pos1 < pos2, "order: {}", html);

--- a/tests/report.rs
+++ b/tests/report.rs
@@ -93,6 +93,8 @@ fn html_report_directory() {
     let html = fs::read_to_string(outdir.path().join("index.html")).unwrap();
     assert!(html.contains("Start:"), "{}", html);
     assert!(html.contains("End:"), "{}", html);
+    assert!(html.contains("<th>Start</th>"), "{}", html);
+    assert!(html.contains("<th>End</th>"), "{}", html);
     let pos1 = html.find("1111").expect("1111");
     let pos2 = html.find("2222").expect("2222");
     assert!(pos1 < pos2, "order: {}", html);


### PR DESCRIPTION
## Summary
- show absolute timestamps on CPU and RSS graphs
- reduce grid lines on the graphs
- display start and end time in `index.html`
- update tests for new index page contents

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_e_684f6305d4888322ab80a7c20eaabb9d